### PR TITLE
ant dist-test fail after clean

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -121,7 +121,7 @@
         </pathconvert>
     </target>
 
-    <target name="dist-test" depends="init-test" description="Compile tests">
+    <target name="dist-test" depends="init-test,dist" description="Compile tests">
         <java fork="true"
               failonerror="true"
               classpath="${test.lib.jars}:${checker.bin}"


### PR DESCRIPTION
Add dist dependency to dist-test target. Let me know if you don't think it is a good idea.
